### PR TITLE
Make sure HF download metrics work, better discoverability on Hugging Face

### DIFF
--- a/models/var.py
+++ b/models/var.py
@@ -10,6 +10,8 @@ from models.basic_var import AdaLNSABlock, SABlock
 from models.helpers import sample_with_top_k_top_p_, gumbel_softmax_with_rng
 from models.vqvae import VQVAE, VectorQuantizer2
 
+from huggingface_hub import PyTorchModelHubMixin
+
 
 class SharedAdaLin(nn.Linear):
     def forward(self, cond_BD):
@@ -304,3 +306,19 @@ class AdaLNBeforeHead(nn.Module):
 class MultiInpIdentity(nn.Module):
     def forward(self, x, *args, **kwargs):
         return x
+
+
+class VARHF(VAR, PyTorchModelHubMixin):
+    def __init__(
+        self,
+        vae_kwargs,
+        num_classes=1000, norm_eps=1e-6, aln=1, aln_gamma_init=1e-3, shared_aln=False, cond_drop_rate=0.1,
+        depth=16, embed_dim=1024, num_heads=16, mlp_ratio=4., drop_rate=0., attn_drop_rate=0., drop_path_rate=0.,
+        layer_scale=-1., tau=4, cos_attn=False,
+        patch_nums=(1, 2, 3, 4, 5, 6, 8, 10, 13, 16),   # 10 steps by default
+        flash_if_available=True, fused_if_available=True,
+    ):
+        vae_local = VQVAE(**vae_kwargs)
+        super().__init__(
+            vae_local, num_classes, norm_eps, aln, aln_gamma_init, shared_aln, cond_drop_rate, depth, embed_dim, num_heads, mlp_ratio, drop_rate, attn_drop_rate, drop_path_rate, layer_scale, tau, cos_attn, patch_nums, flash_if_available, fused_if_available
+        )

--- a/models/var.py
+++ b/models/var.py
@@ -308,7 +308,9 @@ class MultiInpIdentity(nn.Module):
         return x
 
 
-class VARHF(VAR, PyTorchModelHubMixin):
+class VARHF(VAR, PyTorchModelHubMixin,
+            repo_url="https://github.com/FoundationVision/VAR",
+            tags=["image-generation"]):
     def __init__(
         self,
         vae_kwargs,


### PR DESCRIPTION
Dear authors,

I noticed your awesome repository trending on paperswithcode. I'm from Hugging Face and would like to help you make your models easier discoverable and downloadable for people :)

I see all checkpoints are present in a [single repository](https://huggingface.co/FoundationVision/var/tree/main), which means download metrics won't work. 😞 

This PR resolves that by showcasing the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/en/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class, which is a minimal class that allows to easily add functionalities like `from_pretrained`, `save_pretrained`, and `push_to_hub` to any custom `nn.Module`!

Similar to models in the Transformers/Diffusers library, it allows to push and reload models in the format of `safetensors` (for the weights) and a `config.json` (for the model's configuration). It also creates an automated model card, along with tags for better discoverability of your models. Usage is as follows:

```
from models.var import VARHF

model = VARHF.from_pretrained(f"nielsr/var_d16")
```
The corresponding model is here for now: https://huggingface.co/nielsr/var_d16, but I could transfer it (along with the other checkpoints) to your organization.

Here's a [notebook](https://colab.research.google.com/drive/1VQluEqscH2lp6KOl1F8LhxO5z44gGLGb?usp=sharing) regarding how I did that :)

Would you be interested in this integration?

Btw, in the demo_sample notebook, there's an easier way to download checkpoints directly from HF using the [hf_hub_download](https://huggingface.co/docs/huggingface_hub/v0.22.2/en/package_reference/file_download#huggingface_hub.hf_hub_download) method, it's as simple as this:

```python
from huggingface_hub import hf_hub_download

# download checkpoint
vae_ckpt= hf_hub_download(repo_id="FoundationVision/var", filename="vae_ch160v4096z32.pth", repo_type="model")
var_ckpt = hf_hub_download(repo_id="FoundationVision/var", filename=f"var_d{MODEL_DEPTH}.pth", repo_type="model")
```

Kind regards,

Niels
ML @ HF