### PR TITLE
move compute condition out of loop in inference

### DIFF
--- a/models/var.py
+++ b/models/var.py
@@ -157,12 +157,15 @@ class VAR(nn.Module):
         f_hat = sos.new_zeros(B, self.Cvae, self.patch_nums[-1], self.patch_nums[-1])
         
         for b in self.blocks: b.attn.kv_caching(True)
+        cond_BD_or_gss = self.shared_ada_lin(cond_BD)
+        
+        # Autoregressive generation
         for si, pn in enumerate(self.patch_nums):   # si: i-th segment
             ratio = si / self.num_stages_minus_1
             # last_L = cur_L
             cur_L += pn*pn
             # assert self.attn_bias_for_masking[:, :, last_L:cur_L, :cur_L].sum() == 0, f'AR with {(self.attn_bias_for_masking[:, :, last_L:cur_L, :cur_L] != 0).sum()} / {self.attn_bias_for_masking[:, :, last_L:cur_L, :cur_L].numel()} mask item'
-            cond_BD_or_gss = self.shared_ada_lin(cond_BD)
+
             x = next_token_map
             AdaLNSelfAttn.forward
             for b in self.blocks:


### PR DESCRIPTION
Move compute condition out of the autoregressive loop in inference.
The condition (cond_BD) does not change during the autoregressive process, so it's more logical and maybe faster to move it out.