### PR TITLE
Fix: Use config variable for 'more_smooth' parameter to avoid hard-co…

### DIFF
--- a/demo_zero_shot_edit.ipynb
+++ b/demo_zero_shot_edit.ipynb
@@ -282,7 +282,7 @@
     "    with torch.autocast('cuda', enabled=True, dtype=torch.float16, cache_enabled=True):    # using bfloat16 can be faster\n",
     "        recon_B3HW = autoregressive_infer_cfg_with_mask(\n",
     "            var,\n",
-    "            B=B, label_B=label_B, cfg=3, top_k=900, top_p=0.95, g_seed=0, more_smooth=True,\n",
+    "            B=B, label_B=label_B, cfg=3, top_k=900, top_p=0.95, g_seed=0, more_smooth=more_smooth,\n",
     "            input_img_tokens=input_img_tokens, edit_mask=edit_mask\n",
     "        )\n",
     "\n",


### PR DESCRIPTION
### 1. Description of the Change

This pull request addresses a minor inconsistency in the demo script (`demo_zero_shot_edit.ipynb`).

The `autoregressive_infer_cfg_with_mask` function was being called with a hardcoded value `more_smooth=True`, which ignores the `more_smooth` configuration variable defined at the top of the script. This change replaces the hardcoded literal with the variable, allowing the script's behavior to be controlled by the configuration as intended.

### 2. Reason for the Change

The current implementation can cause confusion for users. Even if a user sets `more_smooth = False` to experiment with the model's output, the generation process would still use `more_smooth=True`. This leads to results that do not match the user's configuration.

This fix ensures the code is more intuitive and behaves as expected, improving the user experience for anyone testing the model.

### 3. How to Test

1.  In `demo_zero_shot_edit.ipynb`, set the variable `more_smooth = False`.
2.  Run the script.
3.  Observe that the model now correctly uses the `False` value during generation (e.g., by inspecting the model's internal state or observing the output difference).
4.  Set `more_smooth = True` and confirm that the `True` value is used.

Thank you for the excellent research and for making the code available to the community!